### PR TITLE
Add new route for creating HubSpot leads

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,12 @@
 import os
 import tempfile
 
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, make_response
 from pdfminer.high_level import extract_text
 from docx import Document
+import hubspot
+from pprint import pprint
+from hubspot.crm.companies import SimplePublicObjectInputForCreate, ApiException
 
 app = Flask(__name__)
 
@@ -17,6 +20,10 @@ def parse_docx(file_path):
     for paragraph in document.paragraphs:
         full_text.append(paragraph.text)
     return '\n'.join(full_text)
+
+@app.route('/')
+def index():
+    return jsonify({'message': 'Hello, World!'})
 
 @app.route('/parse', methods=['POST'])
 def parse_file():
@@ -40,9 +47,63 @@ def parse_file():
         else:
             return jsonify({'error': 'Unsupported file type'}), 400
 
-        return jsonify({'text': text})
+        return jsonify({'text': text}), 200
     finally:
         os.unlink(temp_filepath)
+
+@app.route('/new-lead', methods=['POST', 'OPTIONS'])
+def new_lead():
+    if request.method == "OPTIONS": # CORS preflight
+        return _build_cors_preflight_response()
+    elif request.method != "POST":
+        return _corsify_actual_response(jsonify({'error': 'Invalid request method {}'.format(request.method)})), 405
+    
+    client = hubspot.Client.create(access_token=os.environ.get('HS_ACCESS_TOKEN'))
+
+    data = request.json
+    first_name = data.get('first_name')
+    last_name = data.get('last_name')
+    email = data.get('email')
+    company_name = data.get('company_name')
+    company_size = data.get('company_size')
+    source = data.get('source')
+
+    if not first_name or not last_name or not email or not company_name or not company_size or not source:
+        return _corsify_actual_response(jsonify({'error': 'Missing required fields'})), 400
+
+    contact_properties = {
+        "firstname": first_name,
+        "lastname": last_name,
+        "email": email,
+        "numemployees": company_size,
+        "company": company_name,
+        "hs_lead_status": "NEW",
+        "source_url": source,
+    }
+
+    contactObject = SimplePublicObjectInputForCreate(
+        properties=contact_properties,
+    )
+    try:
+        response = client.crm.contacts.basic_api.create(
+            simple_public_object_input_for_create=contactObject
+        )
+        pprint(response)
+    except ApiException as e:
+        return jsonify({'error': e}), 400
+    
+    return _corsify_actual_response(jsonify({'message': 'Lead created successfully'})), 200
+
+def _build_cors_preflight_response():
+    response = make_response()
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    response.headers.add('Access-Control-Allow-Headers', "*")
+    response.headers.add('Access-Control-Allow-Methods', "*")
+    return response
+
+def _corsify_actual_response(response):
+    response.headers.add("Access-Control-Allow-Origin", "*")
+    return response
 
 if __name__ == '__main__':
     app.run(debug=True) 

--- a/app.py
+++ b/app.py
@@ -67,6 +67,7 @@ def new_lead():
     company_name = data.get('company_name')
     company_size = data.get('company_size')
     source = data.get('source')
+    message = data.get('message')
 
     if not first_name or not last_name or not email or not company_name or not company_size or not source:
         return _corsify_actual_response(jsonify({'error': 'Missing required fields'})), 400
@@ -79,6 +80,7 @@ def new_lead():
         "company": company_name,
         "hs_lead_status": "NEW",
         "source_url": source,
+        "message": message
     }
 
     contactObject = SimplePublicObjectInputForCreate(


### PR DESCRIPTION
Adds a new route `/new-lead` to the Flask application for creating HubSpot leads. 

The route accepts a POST request with JSON data containing the required fields for creating a lead (first name, last name, email, company name, company size, and source URL). The contact is then created using the HubSpot CRM SDK.